### PR TITLE
Secure processes by role

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,6 @@ IMAGE_TAG=1.1.0
 KEYCLOAK_USER=admin
 KEYCLOAK_PASSWORD=admin
 KEYCLOAK_HOST=<<INSERT_YOUR_IP>>
+
+REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -2,11 +2,9 @@ import logging
 import traceback
 
 import aiohttp
-import yaml
+from flask import g
 
 import ump.api.providers as providers
-import ump.config as config
-
 
 async def all_processes():
     processes = {}
@@ -44,15 +42,26 @@ async def all_processes():
 
 def _processes_list(results):
     processes = []
+    auth = g.get('auth_token')
+
     for provider in providers.PROVIDERS:
-
+        provider_access = auth is not None and (provider in auth['realm_access']['roles'] or provider in auth['resource_access']['ump-client']['roles'])
+        if provider_access:
+            logging.debug(f"Granting access for model server {provider}")
         try:
-
             # Check if process has special configuration
             for process in results[provider]:
+                id = f"{provider}_{process['id']}"
+                process_access = auth is not None and (id in auth['realm_access']['roles'] or id in auth['resource_access']['ump-client']['roles'])
+                if process_access or provider_access:
+                    logging.debug(f"Granting access for process {process['id']}")
+
+                if not provider_access and not process_access:
+                    logging.debug(f"Not granting access for {process['id']}")
+                    continue
 
                 logging.debug(
-                    f"Checking  process {process['id']} of provider {providers.PROVIDERS[provider]['name']} "
+                    f"Checking process {process['id']} of provider {providers.PROVIDERS[provider]['name']} "
                 )
 
                 if providers.check_process_availability(provider, process["id"]):


### PR DESCRIPTION
Secures processes so that:

* users need to be authenticated to list and execute processes
* users need to have a role corresponding to the model server key in the `providers.yaml`
* OR: users need to have a role corresponding to the model server key and the process key from the `providers.yaml` connected with an underscore, e.g. `modelserver_squareroot`

This implements the thoughts collected in #16 

Note that in order to access e.g. https://modelplatform.cut.hcu-hamburg.de/ you'll need to update your `.env` with the ca-certificate variables.

@herzogrh Please review.