### PR TITLE
Add support for public modelservers

### DIFF
--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -45,18 +45,19 @@ def _processes_list(results):
     auth = g.get('auth_token')
 
     for provider in providers.PROVIDERS:
+        public_access = not "authentication" in providers.PROVIDERS[provider]
         provider_access = auth is not None and (provider in auth['realm_access']['roles'] or provider in auth['resource_access']['ump-client']['roles'])
-        if provider_access:
+        if public_access or provider_access:
             logging.debug(f"Granting access for model server {provider}")
         try:
             # Check if process has special configuration
             for process in results[provider]:
                 id = f"{provider}_{process['id']}"
                 process_access = auth is not None and (id in auth['realm_access']['roles'] or id in auth['resource_access']['ump-client']['roles'])
-                if process_access or provider_access:
+                if public_access or process_access or provider_access:
                     logging.debug(f"Granting access for process {process['id']}")
 
-                if not provider_access and not process_access:
+                if not public_access and not provider_access and not process_access:
                     logging.debug(f"Not granting access for {process['id']}")
                     continue
 


### PR DESCRIPTION
This adds a check to also support modelserver without `authentication`.