### PR TITLE
Drop `sample_size` and `sampling_method` from ensemble

### DIFF
--- a/migrations/versions/1.0.4_remove_sampling_settings_from_ensemble.py
+++ b/migrations/versions/1.0.4_remove_sampling_settings_from_ensemble.py
@@ -1,0 +1,25 @@
+"""Remove sampling settings from ensemble
+
+Revision ID: 1.0.4
+Revises:
+Create Date: 2024-09-23 14:00
+
+"""
+
+from alembic import op
+from sqlalchemy import BigInteger, Column, String
+
+revision = "1.0.4"
+down_revision = "1.0.3"
+branch_labels = "remove_sampling_settings_from_ensemble"
+depends_on = "1.0.3"
+
+
+def upgrade():
+    op.drop_column("ensembles", "sample_size")
+    op.drop_column("ensembles", "sampling_method")
+
+
+def downgrade():
+    op.add_column("ensembles", Column("sample_size", BigInteger()))
+    op.add_column("ensembles", Column("sampling_method", String()))

--- a/src/ump/api/ensemble.py
+++ b/src/ump/api/ensemble.py
@@ -18,8 +18,6 @@ class Ensemble(Base):
     description: Mapped[str] = mapped_column(String())
     user_id: Mapped[str] = mapped_column(String())
     scenario_configs: Mapped[str] = mapped_column(String())
-    sample_size: Mapped[int] = mapped_column(BigInteger())
-    sampling_method: Mapped[str] = mapped_column(String())
     created: Mapped[datetime] = mapped_column(DateTime())
     modified: Mapped[datetime] = mapped_column(DateTime())
 
@@ -29,15 +27,11 @@ class Ensemble(Base):
         description: str,
         user_id: str,
         scenario_configs: str,
-        sample_size: int,
-        sampling_method: str,
     ):
         self.name = name
         self.description = description
         self.user_id = user_id
         self.scenario_configs = scenario_configs
-        self.sample_size = sample_size
-        self.sampling_method = sampling_method
         self.created = datetime.now(timezone.utc)
         self.modified = datetime.now(timezone.utc)
 
@@ -50,8 +44,6 @@ class Ensemble(Base):
             "description": self.description,
             "user_id": self.user_id,
             "scenario_configs": self.scenario_configs,
-            "sample_size": self.sample_size,
-            "sampling_method": self.sampling_method,
         }
 
 

--- a/src/ump/api/routes/ensembles.py
+++ b/src/ump/api/routes/ensembles.py
@@ -37,8 +37,6 @@ def create():
         name=data.get("name"),
         description=data.get("description"),
         user_id=auth.get("sub"),
-        sample_size=data.get("sample_size"),
-        sampling_method=data.get("sampling_method"),
         scenario_configs=json.dumps(data.get("scenario_configs")),
     )
     with Session(engine) as session:


### PR DESCRIPTION
As the sample_size and sampling_method are related to the model the fields can be removed from the ensemble entity.