### PR TITLE
feat: add missing endpoints and entities

### DIFF
--- a/migrations/versions/1.0.8_drop_ensemble_id.py
+++ b/migrations/versions/1.0.8_drop_ensemble_id.py
@@ -1,0 +1,21 @@
+"""Drop ensemble id
+
+Revision ID: 1.0.8
+Revises:
+Create Date: 2024-10-01 14:00
+
+"""
+
+from alembic import op
+from sqlalchemy import BigInteger, Column
+
+revision = "1.0.8"
+down_revision = "1.0.7"
+branch_labels = "drop_ensemble_id"
+depends_on = "1.0.7"
+
+def upgrade():
+    op.drop_column('jobs', 'ensemble_id')
+
+def downgrade():
+    op.add_column('jobs', Column('ensemble_id', BigInteger(), index = True))

--- a/migrations/versions/1.0.9_create_job_comments.py
+++ b/migrations/versions/1.0.9_create_job_comments.py
@@ -1,0 +1,29 @@
+"""Create job comments
+
+Revision ID: 1.0.9
+Revises:
+Create Date: 2024-10-01 14:00
+
+"""
+
+from alembic import op
+from sqlalchemy import BigInteger, Column, DateTime, String
+
+revision = "1.0.9"
+down_revision = "1.0.8"
+branch_labels = "create_job_comments"
+depends_on = "1.0.8"
+
+def upgrade():
+    op.create_table(
+        'job_comments',
+        Column('id', BigInteger(), primary_key = True),
+        Column('user_id', String(), index = True),
+        Column('job_id', String(), index = True),
+        Column('comment', String()),
+        Column("created", DateTime()),
+        Column("modified", DateTime())
+    )
+
+def downgrade():
+    op.drop_table('job_comments')

--- a/src/ump/api/ensemble.py
+++ b/src/ump/api/ensemble.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import ClassVar
 
 from sqlalchemy import BigInteger, DateTime, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, declarative_base
@@ -23,6 +24,7 @@ class Ensemble(Base, SerializerMixin):
     scenario_configs: Mapped[str] = mapped_column(String())
     created: Mapped[datetime] = mapped_column(DateTime())
     modified: Mapped[datetime] = mapped_column(DateTime())
+    jobs_metadata: ClassVar[dict]
 
     def __init__(
         self,

--- a/src/ump/api/job.py
+++ b/src/ump/api/job.py
@@ -32,7 +32,6 @@ class Job:
         "results_metadata",
         "name",
         "process_title",
-        "ensemble_id",
         "process_version",
     ]
 
@@ -57,7 +56,6 @@ class Job:
         self.updated = None
         self.results_metadata = {}
         self.user_id = None
-        self.ensemble_id = None
         self.name = None
         self.process_title = None
         self.process_version = None
@@ -74,7 +72,6 @@ class Job:
         name=None,
         parameters={},
         user=None,
-        ensemble_id=None,
         process_version=None,
     ):
         self._set_attributes(
@@ -85,7 +82,6 @@ class Job:
             name,
             parameters,
             user_id=user,
-            ensemble_id=ensemble_id,
             process_version=process_version,
         )
 
@@ -95,9 +91,9 @@ class Job:
 
         query = """
             INSERT INTO jobs
-            (job_id, remote_job_id, process_id, provider_prefix, provider_url, status, progress, parameters, message, created, started, finished, updated, user_id, process_title, name, ensemble_id, process_version)
+            (job_id, remote_job_id, process_id, provider_prefix, provider_url, status, progress, parameters, message, created, started, finished, updated, user_id, process_title, name, process_version)
             VALUES
-            (%(job_id)s, %(remote_job_id)s, %(process_id)s, %(provider_prefix)s, %(provider_url)s, %(status)s, %(progress)s, %(parameters)s, %(message)s, %(created)s, %(started)s, %(finished)s, %(updated)s, %(user_id)s, %(process_title)s, %(name)s, %(ensemble_id)s, %(process_version)s)
+            (%(job_id)s, %(remote_job_id)s, %(process_id)s, %(provider_prefix)s, %(provider_url)s, %(status)s, %(progress)s, %(parameters)s, %(message)s, %(created)s, %(started)s, %(finished)s, %(updated)s, %(user_id)s, %(process_title)s, %(name)s, %(process_version)s)
         """
         with DBHandler() as db:
             logging.error(self._to_dict())
@@ -114,7 +110,6 @@ class Job:
         name=None,
         parameters={},
         user_id=None,
-        ensemble_id=None,
         process_version=None,
     ):
         self.job_id = job_id
@@ -122,7 +117,6 @@ class Job:
         self.user_id = user_id
         self.process_title = process_title
         self.name = name
-        self.ensemble_id = ensemble_id
         self.process_version = process_version
 
         if remote_job_id and not job_id:
@@ -186,7 +180,6 @@ class Job:
         self.user_id = data["user_id"]
         self.process_title = data["process_title"]
         self.name = data["name"]
-        self.ensemble_id = data["ensemble_id"]
         self.process_version = data['process_version']
 
     def _to_dict(self):
@@ -208,7 +201,6 @@ class Job:
             "parameters": json.dumps(self.parameters),
             "results_metadata": json.dumps(self.results_metadata),
             "user_id": self.user_id,
-            "ensemble_id": self.ensemble_id,
             "process_version": self.process_version,
         }
 
@@ -217,9 +209,9 @@ class Job:
 
         query = """
             UPDATE jobs SET
-            (process_id, provider_prefix, provider_url, status, progress, parameters, message, created, started, finished, updated, results_metadata, ensemble_id, process_version)
+            (process_id, provider_prefix, provider_url, status, progress, parameters, message, created, started, finished, updated, results_metadata, process_version)
             =
-            (%(process_id)s, %(provider_prefix)s, %(provider_url)s, %(status)s, %(progress)s, %(parameters)s, %(message)s, %(created)s, %(started)s, %(finished)s, %(updated)s, %(results_metadata)s, %(ensemble_id)s, %(process_version)s)
+            (%(process_id)s, %(provider_prefix)s, %(provider_url)s, %(status)s, %(progress)s, %(parameters)s, %(message)s, %(created)s, %(started)s, %(finished)s, %(updated)s, %(results_metadata)s, %(process_version)s)
             WHERE job_id = %(job_id)s
         """
         with DBHandler() as db:

--- a/src/ump/api/job_comments.py
+++ b/src/ump/api/job_comments.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column, declarative_base
+from sqlalchemy_serializer import SerializerMixin
+
+Base = declarative_base()
+
+class JobComment(Base, SerializerMixin):
+    __tablename__ = "job_comments"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[str] = mapped_column(String())
+    job_id: Mapped[str] = mapped_column(String())
+    comment: Mapped[str] = mapped_column(String())
+    created: Mapped[datetime] = mapped_column(DateTime())
+    modified: Mapped[datetime] = mapped_column(DateTime())

--- a/src/ump/api/process.py
+++ b/src/ump/api/process.py
@@ -259,7 +259,6 @@ class Process:
                         name=name,
                         parameters=request_body,
                         user=user,
-                        ensemble_id=ensemble_id,
                         process_version=self.version,
                     )
                     job.started = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")

--- a/src/ump/api/routes/jobs.py
+++ b/src/ump/api/routes/jobs.py
@@ -1,28 +1,74 @@
 import asyncio
+from datetime import datetime, timezone
 import json
+import logging
 
 from apiflask import APIBlueprint
 from flask import Response, g, request
 
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from ump.api.job_comments import JobComment
 from ump.api.job import Job
-from ump.api.jobs import get_jobs
+from ump.api.jobs import append_ensemble_list, get_jobs
 
 jobs = APIBlueprint("jobs", __name__)
+
+engine = create_engine("postgresql+psycopg2://postgres:postgres@postgis/cut_dev")
 
 @jobs.route("/", defaults={"page": "index"})
 def index(page):
     args = request.args.to_dict(flat=False) if request.args else {}
     result = get_jobs(args, g.get('auth_token'))
+    if 'include_ensembles' in args and args['include_ensembles']:
+        for job in result['jobs']:
+            append_ensemble_list(job)
     return Response(json.dumps(result), mimetype="application/json")
-
-@jobs.route("/<path:job_id>", methods=["GET"])
-def show(job_id=None):
-    auth = g.get('auth_token')
-    job = Job(job_id, None if auth is None else auth['sub'])
-    return Response(json.dumps(job.display()), mimetype="application/json")
 
 @jobs.route("/<path:job_id>/results", methods=["GET"])
 def results(job_id=None):
     auth = g.get('auth_token')
     job = Job(job_id, None if auth is None else auth['sub'])
     return Response(json.dumps(asyncio.run(job.results())), mimetype="application/json")
+
+@jobs.route("/<path:job_id>/comments", methods=["GET"])
+def get_comments(job_id):
+    auth = g.get("auth_token")
+    if auth is None:
+        return Response("[]", mimetype="application/json")
+    with Session(engine) as session:
+        stmt = (
+            select(JobComment)
+            .where(JobComment.user_id == auth["sub"])
+            .where(JobComment.job_id == job_id)
+        )
+        list = []
+        for comment in session.scalars(stmt).fetchall():
+            list.append(comment.to_dict())
+        return list
+
+@jobs.route("/<path:job_id>/comments", methods=["POST"])
+def create_comment(job_id):
+    auth = g.get("auth_token")
+    if auth is None:
+        logging.error("Not creating comment, no authentication found.")
+        return Response("", mimetype="application/json")
+    comment = JobComment(
+        user_id=auth["sub"],
+        job_id=job_id,
+        comment=request.get_json()["comment"],
+        created=datetime.now(timezone.utc),
+        modified=datetime.now(timezone.utc),
+    )
+    with Session(engine) as session:
+        session.add(comment)
+        session.commit()
+        return Response(mimetype="application/json", status=201)
+
+@jobs.route("/<path:job_id>", methods=["GET"])
+def show(job_id=None):
+    auth = g.get('auth_token')
+    job = Job(job_id, None if auth is None else auth['sub']).display()
+    append_ensemble_list(job)
+    return Response(json.dumps(job), mimetype="application/json")


### PR DESCRIPTION
Adds:

* when executing ensembles, jobs are named after the ensemble, appended with a serial number
* the `ensemble_id` has been removed from the jobs table as they are linked differently now
* when getting jobs you may append the `include_ensembles` query parameter, when set to `true`, a new `ensembles` field will be populated with the linked ensembles (for single jobs this happens automatically)
* adds endpoints to create and retrieve job comments (GET and POST to `/jobs/job-xxx/comment`)
* when getting ensembles, the new field `jobs_metadata` includes a mapping of job status to the number of related jobs having this status like so:

```json
   "jobs_metadata" : {
      "failed" : 3,
      "running" : 9,
      "successful" : 8
   },
```

@herzogrh @KaiVolland Please review.