### PR TITLE
Enable sharing

### DIFF
--- a/migrations/versions/1.0.10_add_share_tables.py
+++ b/migrations/versions/1.0.10_add_share_tables.py
@@ -1,0 +1,33 @@
+"""Add share tables
+
+Revision ID: 1.0.10
+Revises:
+Create Date: 2024-10-02 14:00
+
+"""
+
+from alembic import op
+from sqlalchemy import BigInteger, Column, String
+
+revision = "1.0.10"
+down_revision = "1.0.9"
+branch_labels = "add_share_tables"
+depends_on = "1.0.9"
+
+def upgrade():
+    op.create_table(
+        'jobs_users',
+        Column('id', BigInteger(), primary_key = True),
+        Column('job_id', String(), index = True),
+        Column('user_id', String(), index = True),
+    )
+    op.create_table(
+        'ensembles_users',
+        Column('id', BigInteger(), primary_key = True),
+        Column('ensemble_id', BigInteger(), index = True),
+        Column('user_id', String(), index = True),
+    )
+
+def downgrade():
+    op.drop_table('jobs_users')
+    op.drop_table('ensembles_users')

--- a/src/ump/api/ensemble.py
+++ b/src/ump/api/ensemble.py
@@ -14,6 +14,20 @@ class JobsEnsembles(Base, SerializerMixin):
     ensemble_id: Mapped[int] = mapped_column(BigInteger())
     job_id: Mapped[int] = mapped_column(String())
 
+class JobsUsers(Base, SerializerMixin):
+    __tablename__ = 'jobs_users'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    job_id: Mapped[str] = mapped_column(String())
+    user_id: Mapped[str] = mapped_column(String())
+
+class EnsemblesUsers(Base, SerializerMixin):
+    __tablename__ = 'ensembles_users'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    ensemble_id: Mapped[int] = mapped_column(BigInteger())
+    user_id: Mapped[str] = mapped_column(String())
+
 class Ensemble(Base, SerializerMixin):
     __tablename__ = "ensembles"
 

--- a/src/ump/api/job.py
+++ b/src/ump/api/job.py
@@ -146,12 +146,12 @@ class Job:
 
     def _init_from_db(self, job_id, user):
         query = """
-      SELECT * FROM jobs WHERE job_id = %(job_id)s
+      SELECT * FROM jobs j left join jobs_users u on j.job_id = u.job_id WHERE j.job_id = %(job_id)s
     """
         if user is None:
-            query += " and user_id is null"
+            query += " and j.user_id is null"
         else:
-            query += f" and (user_id = '{user}' or user_id is null)"
+            query += f" and (j.user_id = '{user}' or j.user_id is null or u.user_id = '{user}')"
 
         with DBHandler() as db:
             job_details = db.run_query(query, query_params={"job_id": job_id})

--- a/src/ump/api/jobs.py
+++ b/src/ump/api/jobs.py
@@ -28,15 +28,15 @@ def get_jobs(args, user = None):
 
   jobs = []
   query = """
-    SELECT job_id FROM jobs
+    SELECT j.job_id FROM jobs j left join jobs_users u on j.job_id = u.job_id
   """
   query_params = {}
   conditions = []
   user = None if user is None else user['sub']
   if user is not None:
-    conditions.append(f"user_id = '{user}' or user_id is null")
+    conditions.append(f"j.user_id = '{user}' or j.user_id is null or u.user_id = '{user}'")
   else:
-    conditions.append('user_id is null')
+    conditions.append('j.user_id is null')
 
   if 'processID' in args and args['processID']:
     # this processID is actually the process_id_with_prefix!!!
@@ -112,7 +112,7 @@ def next_links(page, limit, count_jobs):
 
 def count(conditions, query_params):
   count_query = """
-    SELECT count(*) FROM jobs
+    SELECT count(*) FROM jobs j left join jobs_users u on j.job_id = u.job_id
   """
   with DBHandler() as db:
     count_jobs = db.run_query(

--- a/src/ump/api/keycloak.py
+++ b/src/ump/api/keycloak.py
@@ -1,0 +1,24 @@
+from keycloak import KeycloakAdmin
+from keycloak import KeycloakOpenIDConnection
+from os import environ as env
+
+keycloak_connection = KeycloakOpenIDConnection(
+                        server_url=f"{env['KEYCLOAK_PROTOCOL']}://{env['KEYCLOAK_HOST']}/auth/",
+                        username=env['KEYCLOAK_USER'],
+                        password=env['KEYCLOAK_PASSWORD'],
+                        realm_name="master",
+                        user_realm_name="master",
+                        client_id="admin-cli",
+                        verify=True)
+
+keycloak_admin = KeycloakAdmin(connection=keycloak_connection)
+keycloak_admin.change_current_realm('UrbanModelPlatform')
+
+def find_user_id_by_email(email):
+  users = keycloak_admin.get_users({
+    'email': email
+  })
+  for user in users:
+    if user['email'] == email:
+      return user['id']
+  return None


### PR DESCRIPTION
Adds the possibility to share jobs and ensembles. This is implemented by introducing two new tables, each containing a user id and a job/ensemble id respectively.

Endpoints to share are implemented to share ensembles and jobs using a user's email.

@KaiVolland @herzogrh Please review.