### PR TITLE
Fix/remote process timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 #---- App settings ----
 # The API_SERVER_URL is only used to return the complete URL in the result of the job details as specified in OGC.
 # Should be the base url to the api.
-
+UMP_SERVER_TIMEOUT=30
 UMP_LOG_LEVEL=DEBUG
 UMP_PROVIDERS_FILE=providers.yaml
 UMP_API_SERVER_URL=localhost:5000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.1.0rc2+fix-error-handling"
+version = "2.1.0rc3+fix-error-handling"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.1.0rc3+fix-error-handling"
+version = "2.1.0rc5+fix-remote-process-timeout"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+
+export UMP_SERVER_TIMEOUT="${UMP_SERVER_TIMEOUT:-30}"
+
 flask db upgrade
 
 echo "Running API Server in production mode."

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -75,7 +75,7 @@ class Process:
         # for what purpose? -> security! -if a user selects a process which is not
         # confiured to be available, but exists
         try:
-            process_config = providers.load_process_config(
+            process_config = providers.get_process_config(
                 self.provider_prefix, self.process_id
             )
         except ValueError as e:

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -79,6 +79,8 @@ class Process:
                 self.provider_prefix, self.process_id
             )
         except ValueError as e:
+            logger.error(e)
+
             raise OGCProcessException(
                 OGCExceptionResponse(
                     type="http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/no-such-process",

--- a/src/ump/api/models/providers_config.py
+++ b/src/ump/api/models/providers_config.py
@@ -1,6 +1,9 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BaseModel, Field, HttpUrl, SecretStr, TypeAdapter, model_validator
+from pydantic import (
+    BaseModel, Field, HttpUrl, SecretStr, TypeAdapter,
+    field_validator, model_validator
+)
 
 # a type alias to give context to an otherwise generic str
 ProviderName: TypeAlias = Annotated[str, Field(
@@ -119,6 +122,14 @@ class ProviderConfig(BaseModel):
             "and process properties as value."
         )
     )
+
+    @field_validator("server_url", mode="before")
+    def ensure_trailing_slash(cls, value: str) -> HttpUrl:
+        """Ensure server_url has a trailing slash."""
+        
+        if not str(value).endswith("/"):
+            value += "/"
+        return HttpUrl(value)
 
 # a TypeAlias to give context to an otherwise generic dict
 ModelServers: TypeAlias = Annotated[

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -70,8 +70,12 @@ async def fetch_provider_processes(
     try:
         provider_auth = authenticate_provider(provider_config)
         
-        results = await fetch_processes_from_provider(
-            session, provider_config, provider_auth
+        results = await fetch_json(
+            session=session,
+            url=f"{provider_config.server_url}",
+            raise_for_status=True,
+            headers={"Content-type": "application/json", "Accept": "application/json"},
+            auth=provider_auth
         )
 
         if "processes" in results:

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -86,9 +86,18 @@ async def fetch_provider_processes(
                 ):
                     process["id"] = f"{provider_name}:{process_id}"
                     provider_processes.append(process)
+        
+        logger.error(
+            "The response from the remote service was not valid. "
+            "URL: %s, Content: %s",
+            provider_config.server_url,
+            results
+        )
 
-    except aiohttp.ClientError as e:
+    # Note: fetch_json raises OGCProcessException on errors
+    except OGCProcessException as e:
         logger.error("HTTP error while accessing provider %s: %s", provider_name, e)
+
     except Exception as e:
         logger.error("Unexpected error while processing provider %s: %s", provider_name, e)
         traceback.print_exc()

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -172,7 +172,8 @@ def is_process_visible(
     # Log the specific condition(s) that grant access
     if process_config.anonymous_access:
         logger.info(
-            "Granting access for process %s: Anonymous access is allowed.",
+            "Granting access for process %s:%s: Anonymous access is allowed.",
+            provider_name,
             process_id
         )
 

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -42,7 +42,8 @@ async def load_processes():
         # Create a list of tasks for fetching processes concurrently
         tasks = [
             fetch_provider_processes(
-                session, provider_name, provider_config, realm_roles, client_roles
+                session, provider_name,
+                provider_config, realm_roles, client_roles
             )
             for provider_name, provider_config in get_providers().items()
         ]
@@ -78,6 +79,8 @@ async def fetch_provider_processes(
             auth=provider_auth
         )
 
+        # TODO: instead of manually checking for a key, we should validate the response
+        # using a pydantic model or json schema!
         if "processes" in results:
             for process in results["processes"]:
                 process_id = process["id"]

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -37,7 +37,7 @@ async def load_processes():
     ) # remote server needs to answer in time, because we make multiple requests!
 
     async with aiohttp.ClientSession(
-        raise_for_status=True, timeout=client_timeout
+        raise_for_status=False, timeout=client_timeout
     ) as session:
         # Create a list of tasks for fetching processes concurrently
         tasks = [

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -73,7 +73,7 @@ async def fetch_provider_processes(
         
         results = await fetch_json(
             session=session,
-            url=f"{provider_config.server_url}",
+            url=f"{provider_config.server_url}processes",
             raise_for_status=True,
             headers={"Content-type": "application/json", "Accept": "application/json"},
             auth=provider_auth

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -93,7 +93,7 @@ async def fetch_provider_processes(
                     continue
 
                 process_config = provider_config.processes[process_id]
-                if is_process_visible(
+                if has_user_access_rights(
                     process_id, provider_name, process_config,
                     realm_roles, client_roles
                 ):
@@ -138,7 +138,7 @@ async def fetch_processes_from_provider(session, provider_config, provider_auth)
         )
         raise
 
-def is_process_visible(
+def has_user_access_rights(
     process_id: str,
     provider_name: str,
     process_config: ProcessConfig,

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -47,7 +47,7 @@ async def load_processes():
 
         # Process results
         for result in results:
-            if isinstance(result, Exception):
+            if isinstance(result, BaseException):
                 logger.error("Error fetching processes: %s", result)
             else:
                 processes.extend(result)

--- a/src/ump/api/providers.py
+++ b/src/ump/api/providers.py
@@ -1,7 +1,9 @@
 import atexit
-import logging
+import time
 from logging import getLogger
-from threading import Lock
+from threading import Lock, Timer
+import threading
+from typing import Optional
 
 import aiohttp
 import yaml
@@ -19,33 +21,97 @@ from ump.config import app_settings as config
 
 logger = getLogger(__name__)
 
+# Thread-safe provider storage
 PROVIDERS: ModelServers = {}
-PROVIDERS_LOCK = Lock()  # Thread-safe lock for updating PROVIDERS
+PROVIDERS_LOCK = Lock()
+RELOAD_TIMER: Optional[Timer] = None
+DEBOUNCE_DELAY = 0.5  # 500ms debounce
 
 
 class ProviderLoader(FileSystemEventHandler):
-    def on_modified(self, event):
-        logger.info("File modified: %s", event.src_path)
-        if event.src_path == config.UMP_PROVIDERS_FILE.absolute().as_posix():
-            self.load_providers()
+    def __init__(self):
+        self.last_reload = 0
+        self.reload_lock = threading.Lock()
+
+    # need to listen on any event, not just file changes for k8s configmap updates
+    def on_any_event(self, event):
+        # Ignore directory events
+        if event.is_directory:
+            return
+            
+        logger.info("File event: %s on %s", event.event_type, event.src_path)
+
+        event.src_path = str(event.src_path)
+        
+        # Check if the event affects our config file
+        config_path = config.UMP_PROVIDERS_FILE.absolute().as_posix()
+
+        endswith = event.src_path.endswith(config.UMP_PROVIDERS_FILE.name)
+        contains = '..data' in event.src_path
+        
+        if (
+            event.src_path == config_path or
+            endswith or
+            contains
+        ):
+            self._debounced_reload()
+
+    def _debounced_reload(self):
+        """Debounce rapid file changes to avoid reload storms"""
+        global RELOAD_TIMER
+        
+        # Cancel existing timer
+        if RELOAD_TIMER:
+            RELOAD_TIMER.cancel()
+        
+        # Schedule debounced reload
+        RELOAD_TIMER = Timer(DEBOUNCE_DELAY, self.load_providers)
+        RELOAD_TIMER.start()
 
     def load_providers(self):
         logger.info("(Re)Loading providers from %s", config.UMP_PROVIDERS_FILE)
+        
+        # Create new providers dict (don't modify global state yet)
+        new_providers = {}
+        
         try:
             with open(config.UMP_PROVIDERS_FILE, encoding="UTF-8") as file:
                 if content := yaml.safe_load(file):
+                    # Validate before applying
                     validated_content = model_servers_adapter.validate_python(content)
-                    with PROVIDERS_LOCK:  # Ensure thread-safe update
-                        # Update PROVIDERS in place
-                        PROVIDERS.clear()
-                        PROVIDERS.update(validated_content)
-                        logger.info("Providers (re)loaded successfully")
+                    new_providers.update(validated_content)
+                    
+                    # Atomic update with rollback capability
+                    self._atomic_update(new_providers)
+                    logger.info("Providers (re)loaded successfully")
+                else:
+                    logger.warning("Providers file is empty, keeping current configuration")
+                    
         except FileNotFoundError:
             logger.error("Providers file not found: %s", config.UMP_PROVIDERS_FILE)
         except yaml.YAMLError as e:
             logger.error("Failed to parse providers file: %s", e)
         except ValidationError as e:
             logger.error("Validation error in providers file: %s", e)
+        except Exception as e:
+            logger.error("Unexpected error loading providers: %s", e)
+
+    def _atomic_update(self, new_providers: ModelServers):
+        """Atomically update providers with rollback capability"""
+        global PROVIDERS
+        
+        with PROVIDERS_LOCK:
+            # Store old providers for potential rollback
+            old_providers = PROVIDERS
+        try:
+            # Create a new dict with copied Pydantic models
+            PROVIDERS = {
+                name: provider.model_copy(deep=True) 
+                for name, provider in new_providers.items()
+            }
+        except Exception as e:
+            PROVIDERS = old_providers
+            raise
 
 
 # Initialize the ProviderLoader and load providers initially
@@ -55,57 +121,104 @@ provider_loader.load_providers()  # Trigger initial loading
 observer = PollingObserver()
 observer.schedule(
     provider_loader,
-    config.UMP_PROVIDERS_FILE.absolute().as_posix(),  # Simplified path handling
-    recursive=False,
+    config.UMP_PROVIDERS_FILE.parent.as_posix(),  # Watch directory, not file
+    recursive=False
 )
 observer.start()
 
+def cleanup():
+    """Cleanup function for graceful shutdown"""
+    global RELOAD_TIMER
+    
+    if RELOAD_TIMER:
+        RELOAD_TIMER.cancel()
+    
+    observer.stop()
+    observer.join(timeout=5)  # Give it 5 seconds to stop gracefully
+
 # Graceful shutdown for observer
-atexit.register(observer.stop)
+atexit.register(cleanup)
 
 
 def get_providers() -> ModelServers:
-    return PROVIDERS
+    """Get a copy of current providers (thread-safe and immutable)"""
+    with PROVIDERS_LOCK:
+        return PROVIDERS.copy()
+
+
+def get_provider(provider_name: str) -> Optional[ProviderConfig]:
+    """Get a specific provider by name (thread-safe)"""
+    with PROVIDERS_LOCK:
+        return PROVIDERS.get(provider_name)
 
 
 def authenticate_provider(provider: ProviderConfig):
+    """Create authentication object for a provider"""
     auth = None
     if provider.authentication:
         auth = aiohttp.BasicAuth(
-            provider.authentication.user,
-            provider.authentication.password.get_secret_value(),
+            provider.authentication.user, 
+            provider.authentication.password.get_secret_value()
         )
     return auth
 
 
-def load_process_config(
-    provider: str, process_id: str
-) -> ProcessConfig:
-
-    with PROVIDERS_LOCK:  # Ensure thread-safe access
-        try:
-            processes = PROVIDERS[provider].processes
+def check_process_availability(provider: str, process_id: str) -> bool:
+    """Check if a process is available and not excluded"""
+    with PROVIDERS_LOCK:
+        if (
+            provider in PROVIDERS and 
+            process_id in PROVIDERS[provider].processes
+        ):
+            process: ProcessConfig = PROVIDERS[provider].processes[process_id]
+            available = not process.exclude
             
-            # load process configuration
-            process_config: ProcessConfig = processes[process_id]
-
-            if process_config.exclude:
+            if process.exclude:
                 logger.debug("Excluding process %s based on configuration", process_id)
-        except KeyError:
-            logger.error(
-                "Provider '%s' or process '%s' not found in PROVIDERS",
-                provider,
-                process_id,
-            )
-            raise ValueError(
-                f"Provider '{provider}' or process '{process_id}' not found"
-            )
-
-        return process_config
+            
+            return available
+    
+    return False
 
 
-def check_result_storage(provider, process_id):
-    with PROVIDERS_LOCK:  # Ensure thread-safe access
-        if provider in PROVIDERS and process_id in PROVIDERS[provider].processes:
+def check_result_storage(provider: str, process_id: str) -> Optional[str]:
+    """Get the result storage type for a process"""
+    with PROVIDERS_LOCK:
+        if (
+            provider in PROVIDERS
+            and process_id in PROVIDERS[provider].processes
+        ):
             return PROVIDERS[provider].processes[process_id].result_storage
     return None
+
+
+def get_process_config(provider: str, process_id: str) -> Optional[ProcessConfig]:
+    """Get complete process configuration"""
+    with PROVIDERS_LOCK:
+        if (
+            provider in PROVIDERS
+            and process_id in PROVIDERS[provider].processes
+        ):
+            return PROVIDERS[provider].processes[process_id]
+    return None
+
+
+def list_providers() -> list[str]:
+    """Get list of all provider names"""
+    with PROVIDERS_LOCK:
+        return list(PROVIDERS.keys())
+
+
+def list_processes(provider: str) -> list[str]:
+    """Get list of all process IDs for a provider"""
+    with PROVIDERS_LOCK:
+        if provider in PROVIDERS:
+            return list(PROVIDERS[provider].processes.keys())
+    return []
+
+
+# Health check function
+def is_healthy() -> bool:
+    """Check if the provider loader is healthy"""
+    with PROVIDERS_LOCK:
+        return len(PROVIDERS) > 0 and observer.is_alive()

--- a/src/ump/api/providers.py
+++ b/src/ump/api/providers.py
@@ -200,7 +200,10 @@ def get_process_config(provider: str, process_id: str) -> Optional[ProcessConfig
             and process_id in PROVIDERS[provider].processes
         ):
             return PROVIDERS[provider].processes[process_id]
-    return None
+    
+    raise ValueError(
+        f"Process '{process_id}' not found for provider '{provider}'"
+    )
 
 
 def list_providers() -> list[str]:

--- a/src/ump/config.py
+++ b/src/ump/config.py
@@ -6,6 +6,8 @@ from pydantic_settings import BaseSettings
 from rich import print
 
 logger = logging.getLogger(__name__)
+
+
 # using pydantic_settings to manage environment variables
 # and do automatic type casting in a central place
 class UmpSettings(BaseSettings):
@@ -28,14 +30,17 @@ class UmpSettings(BaseSettings):
     UMP_GEOSERVER_WORKSPACE_NAME: str = "UMP"
     UMP_GEOSERVER_USER: str = "geoserver"
     UMP_GEOSERVER_PASSWORD: SecretStr = SecretStr("geoserver")
-    UMP_GEOSERVER_CONNECTION_TIMEOUT: int = 60 # seconds
-    UMP_JOB_DELETE_INTERVAL: int = 240 # minutes
+    UMP_GEOSERVER_CONNECTION_TIMEOUT: int = 60  # seconds
+    UMP_JOB_DELETE_INTERVAL: int = 240  # minutes
     UMP_KEYCLOAK_URL: HttpUrl = HttpUrl("http://keycloak:8080/auth")
     UMP_KEYCLOAK_REALM: str = "UrbanModelPlatform"
     UMP_KEYCLOAK_CLIENT_ID: str = "ump-client"
     UMP_KEYCLOAK_USER: str = "admin"
     UMP_KEYCLOAK_PASSWORD: SecretStr = SecretStr("admin")
     UMP_API_SERVER_URL_PREFIX: str = "/"
+
+    # Gunicorn default timeout is 30 seconds
+    UMP_SERVER_TIMEOUT: int = 30
 
     @computed_field
     @property
@@ -60,6 +65,7 @@ class UmpSettings(BaseSettings):
         if not value.endswith("/"):
             value += "/"
         return value
+
 
 app_settings = UmpSettings()
 app_settings.print_settings()

--- a/src/ump/utils.py
+++ b/src/ump/utils.py
@@ -43,12 +43,8 @@ async def fetch_json(
     try:
         async with session.get(url, **kwargs) as response:
             try:
+                # is the response JSON?
                 response_data = await response.json()
-                
-                if raise_for_status:
-                    response.raise_for_status()
-
-                return response_data
 
             except aiohttp.ContentTypeError:
                 text = await response.text()
@@ -68,6 +64,14 @@ async def fetch_json(
                         instance=None
                     )
                 )
+            
+            # is the response ok?
+            if raise_for_status:
+                response.raise_for_status()
+
+            # if all went good, go!
+            return response_data
+
     except asyncio.TimeoutError:
         logger.error(
             "Timeout when requesting remote service. URL: %s",


### PR DESCRIPTION
This fix ensures that the requests being made to query remote servers have a small(!) timeout, to make user experience smooth. Also, it should fix a problem where the flask server responded with 500 Server error where the UMP waits longer for a remote server response than the default timeout for flask workers (30 seconds).

Additionally, this timout can be optionally adjusted. UMP operator should make sure that all consecutive requests terminate within the flask timeout setting. Otherwise flask kills the worker and the user gets a 500 error response! 