### PR TITLE
Fix/insert failure when authorized

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 #---- App settings ----
 # The API_SERVER_URL is only used to return the complete URL in the result of the job details as specified in OGC.
 # Should be the base url to the api.
-
+UMP_SERVER_TIMEOUT=30
 UMP_LOG_LEVEL=DEBUG
 UMP_PROVIDERS_FILE=providers.yaml
 UMP_API_SERVER_URL=localhost:5000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.1.0rc5+fix-remote-process-timeout"
+version = "2.1.0rc6+fix-unauthorized-response"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.1.0rc6+fix-unauthorized-response"
+version = "2.1.0rc7+fix-unauthorized-response"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.1.0rc3+fix-error-handling"
+version = "2.1.0rc5+fix-remote-process-timeout"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+
+export UMP_SERVER_TIMEOUT="${UMP_SERVER_TIMEOUT:-30}"
+
 flask db upgrade
 
 echo "Running API Server in production mode."

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -301,7 +301,7 @@ class Process:
 
         if process_config.deterministic:
             return None
-
+        # BUG: this fails because of implicit conversion of json to text
         sql = """
         select job_id from jobs where hash = encode(
             sha512(

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -305,8 +305,9 @@ class Process:
         sql = """
         select job_id from jobs where hash = encode(
             sha512(
-                (
-                    %(parameters)s :: json :: text || %(process_version)s || %(user_id)s) :: bytea
+                convert_to(
+                    %(parameters)s :: json :: text || %(process_version)s || %(user_id)s) :: bytea,
+                    'UTF8'
                 ),
             'base64'
         )

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -79,6 +79,8 @@ class Process:
                 self.provider_prefix, self.process_id
             )
         except ValueError as e:
+            logger.error(e)
+
             raise OGCProcessException(
                 OGCExceptionResponse(
                     type="http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/no-such-process",

--- a/src/ump/api/models/providers_config.py
+++ b/src/ump/api/models/providers_config.py
@@ -1,6 +1,9 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BaseModel, Field, HttpUrl, SecretStr, TypeAdapter, model_validator
+from pydantic import (
+    BaseModel, Field, HttpUrl, SecretStr, TypeAdapter,
+    field_validator, model_validator
+)
 
 # a type alias to give context to an otherwise generic str
 ProviderName: TypeAlias = Annotated[str, Field(
@@ -119,6 +122,14 @@ class ProviderConfig(BaseModel):
             "and process properties as value."
         )
     )
+
+    @field_validator("server_url", mode="before")
+    def ensure_trailing_slash(cls, value: str) -> HttpUrl:
+        """Ensure server_url has a trailing slash."""
+        
+        if not str(value).endswith("/"):
+            value += "/"
+        return HttpUrl(value)
 
 # a TypeAlias to give context to an otherwise generic dict
 ModelServers: TypeAlias = Annotated[

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -70,8 +70,12 @@ async def fetch_provider_processes(
     try:
         provider_auth = authenticate_provider(provider_config)
         
-        results = await fetch_processes_from_provider(
-            session, provider_config, provider_auth
+        results = await fetch_json(
+            session=session,
+            url=f"{provider_config.server_url}",
+            raise_for_status=True,
+            headers={"Content-type": "application/json", "Accept": "application/json"},
+            auth=provider_auth
         )
 
         if "processes" in results:

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -86,9 +86,18 @@ async def fetch_provider_processes(
                 ):
                     process["id"] = f"{provider_name}:{process_id}"
                     provider_processes.append(process)
+        
+        logger.error(
+            "The response from the remote service was not valid. "
+            "URL: %s, Content: %s",
+            provider_config.server_url,
+            results
+        )
 
-    except aiohttp.ClientError as e:
+    # Note: fetch_json raises OGCProcessException on errors
+    except OGCProcessException as e:
         logger.error("HTTP error while accessing provider %s: %s", provider_name, e)
+
     except Exception as e:
         logger.error("Unexpected error while processing provider %s: %s", provider_name, e)
         traceback.print_exc()

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -101,13 +101,13 @@ async def fetch_provider_processes(
                 ):
                     process["id"] = f"{provider_name}:{process_id}"
                     provider_processes.append(process)
-        
-        logger.error(
-            "The response from the remote service was not valid. "
-            "URL: %s, Content: %s",
-            provider_config.server_url,
-            results
-        )
+        else:
+            logger.error(
+                "The response from the remote service was not valid. "
+                "URL: %s, Content: %s",
+                provider_config.server_url,
+                results
+            )
 
     # Note: fetch_json raises OGCProcessException on errors
     except OGCProcessException as e:

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -172,7 +172,8 @@ def is_process_visible(
     # Log the specific condition(s) that grant access
     if process_config.anonymous_access:
         logger.info(
-            "Granting access for process %s: Anonymous access is allowed.",
+            "Granting access for process %s:%s: Anonymous access is allowed.",
+            provider_name,
             process_id
         )
 

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -42,7 +42,8 @@ async def load_processes():
         # Create a list of tasks for fetching processes concurrently
         tasks = [
             fetch_provider_processes(
-                session, provider_name, provider_config, realm_roles, client_roles
+                session, provider_name,
+                provider_config, realm_roles, client_roles
             )
             for provider_name, provider_config in get_providers().items()
         ]
@@ -78,6 +79,8 @@ async def fetch_provider_processes(
             auth=provider_auth
         )
 
+        # TODO: instead of manually checking for a key, we should validate the response
+        # using a pydantic model or json schema!
         if "processes" in results:
             for process in results["processes"]:
                 process_id = process["id"]

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -37,7 +37,7 @@ async def load_processes():
     ) # remote server needs to answer in time, because we make multiple requests!
 
     async with aiohttp.ClientSession(
-        raise_for_status=True, timeout=client_timeout
+        raise_for_status=False, timeout=client_timeout
     ) as session:
         # Create a list of tasks for fetching processes concurrently
         tasks = [

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -40,6 +40,8 @@ async def load_processes():
         raise_for_status=False, timeout=client_timeout
     ) as session:
         # Create a list of tasks for fetching processes concurrently
+        #TODO: it would make more sense if, not all processes are fetched,
+        # but only those that are configured and are accessible by the user
         tasks = [
             fetch_provider_processes(
                 session, provider_name,

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -73,7 +73,7 @@ async def fetch_provider_processes(
         
         results = await fetch_json(
             session=session,
-            url=f"{provider_config.server_url}",
+            url=f"{provider_config.server_url}processes",
             raise_for_status=True,
             headers={"Content-type": "application/json", "Accept": "application/json"},
             auth=provider_auth

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -93,7 +93,7 @@ async def fetch_provider_processes(
                     continue
 
                 process_config = provider_config.processes[process_id]
-                if is_process_visible(
+                if has_user_access_rights(
                     process_id, provider_name, process_config,
                     realm_roles, client_roles
                 ):
@@ -138,7 +138,7 @@ async def fetch_processes_from_provider(session, provider_config, provider_auth)
         )
         raise
 
-def is_process_visible(
+def has_user_access_rights(
     process_id: str,
     provider_name: str,
     process_config: ProcessConfig,

--- a/src/ump/api/processes.py
+++ b/src/ump/api/processes.py
@@ -47,7 +47,7 @@ async def load_processes():
 
         # Process results
         for result in results:
-            if isinstance(result, Exception):
+            if isinstance(result, BaseException):
                 logger.error("Error fetching processes: %s", result)
             else:
                 processes.extend(result)

--- a/src/ump/api/providers.py
+++ b/src/ump/api/providers.py
@@ -192,7 +192,7 @@ def check_result_storage(provider: str, process_id: str) -> Optional[str]:
     return None
 
 
-def get_process_config(provider: str, process_id: str) -> Optional[ProcessConfig]:
+def get_process_config(provider: str, process_id: str) -> ProcessConfig:
     """Get complete process configuration"""
     with PROVIDERS_LOCK:
         if (

--- a/src/ump/api/routes/processes.py
+++ b/src/ump/api/routes/processes.py
@@ -27,6 +27,8 @@ def show(process_id_with_prefix=None):
 def execute(process_id_with_prefix=None):
     auth = g.get('auth_token')
     process = Process(process_id_with_prefix)
+
+    # extract unique user ID ('sub') from auth token if available
     result = process.execute(request.json, None if auth is None else auth['sub'])
     return Response(json.dumps(result), status=201, mimetype="application/json")
 

--- a/src/ump/config.py
+++ b/src/ump/config.py
@@ -6,6 +6,8 @@ from pydantic_settings import BaseSettings
 from rich import print
 
 logger = logging.getLogger(__name__)
+
+
 # using pydantic_settings to manage environment variables
 # and do automatic type casting in a central place
 class UmpSettings(BaseSettings):
@@ -28,14 +30,17 @@ class UmpSettings(BaseSettings):
     UMP_GEOSERVER_WORKSPACE_NAME: str = "UMP"
     UMP_GEOSERVER_USER: str = "geoserver"
     UMP_GEOSERVER_PASSWORD: SecretStr = SecretStr("geoserver")
-    UMP_GEOSERVER_CONNECTION_TIMEOUT: int = 60 # seconds
-    UMP_JOB_DELETE_INTERVAL: int = 240 # minutes
+    UMP_GEOSERVER_CONNECTION_TIMEOUT: int = 60  # seconds
+    UMP_JOB_DELETE_INTERVAL: int = 240  # minutes
     UMP_KEYCLOAK_URL: HttpUrl = HttpUrl("http://keycloak:8080/auth")
     UMP_KEYCLOAK_REALM: str = "UrbanModelPlatform"
     UMP_KEYCLOAK_CLIENT_ID: str = "ump-client"
     UMP_KEYCLOAK_USER: str = "admin"
     UMP_KEYCLOAK_PASSWORD: SecretStr = SecretStr("admin")
     UMP_API_SERVER_URL_PREFIX: str = "/"
+
+    # Gunicorn default timeout is 30 seconds
+    UMP_SERVER_TIMEOUT: int = 30
 
     @computed_field
     @property
@@ -60,6 +65,7 @@ class UmpSettings(BaseSettings):
         if not value.endswith("/"):
             value += "/"
         return value
+
 
 app_settings = UmpSettings()
 app_settings.print_settings()

--- a/src/ump/main.py
+++ b/src/ump/main.py
@@ -169,6 +169,8 @@ def check_jwt():
     schedule.run_pending()
     auth = request.authorization
 
+    # TODO: this needs to be improved, it should not fail the app
+    # and error messages must adopt OGCProcessException
     if auth is not None:
         # need exception handling here to avoid app failure!
         try:

--- a/src/ump/main.py
+++ b/src/ump/main.py
@@ -59,6 +59,11 @@ dictConfig(
                 "handlers": ["wsgi"],
                 "propagate": False,
             },
+            "ump.api.models.process": {  # Configure the logger for processes.py
+                "level": config.UMP_LOG_LEVEL,
+                "handlers": ["wsgi"],
+                "propagate": False,
+            },
         },
     }
 )

--- a/src/ump/utils.py
+++ b/src/ump/utils.py
@@ -43,12 +43,8 @@ async def fetch_json(
     try:
         async with session.get(url, **kwargs) as response:
             try:
+                # is the response JSON?
                 response_data = await response.json()
-                
-                if raise_for_status:
-                    response.raise_for_status()
-
-                return response_data
 
             except aiohttp.ContentTypeError:
                 text = await response.text()
@@ -68,6 +64,14 @@ async def fetch_json(
                         instance=None
                     )
                 )
+            
+            # is the response ok?
+            if raise_for_status:
+                response.raise_for_status()
+
+            # if all went good, go!
+            return response_data
+
     except asyncio.TimeoutError:
         logger.error(
             "Timeout when requesting remote service. URL: %s",


### PR DESCRIPTION
Raw queries in check_for_cache (api/models/process.py) and  Job.insert (api/models/job.py) failed when user_id was set. This PR does a quick fix using PostgreSQLs convert_to() function to convert concatenated string into UTF8 bytes before hashing. 

Generally, these raw queries aren`t part of the migration system currently and they use not normalized tables. Therefor the whole Job/Process persistence management needs an overhaul using proper SQL models and normalization.