### PR TITLE
Fix/create job hash in python

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.2.5"
+current_version = "2.2.6"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.2.3"
+current_version = "2.2.4"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.2.4"
+current_version = "2.2.5"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.2.2"
+current_version = "2.2.3"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,4 +21,6 @@
     "ruff.importStrategy": "fromEnvironment",
     "black-formatter.importStrategy": "fromEnvironment",
     "python.analysis.typeCheckingMode": "basic",
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.2.6"
+version = "2.2.7"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.2.3"
+version = "2.2.4"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.2.2"
+version = "2.2.3"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.2.4"
+version = "2.2.5"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.2.5"
+version = "2.2.6"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/src/ump/api/models/job.py
+++ b/src/ump/api/models/job.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import json
 import logging
 import re
@@ -7,17 +9,16 @@ from datetime import datetime, timezone
 import aiohttp
 import geopandas as gpd
 
-from ump.api import remote_auth
-from ump.api.models.ogc_exception import OGCExceptionResponse
 import ump.api.providers as providers
+from ump.api import remote_auth
 from ump.api.db_handler import DBHandler
 from ump.api.models.job_status import JobStatus
+from ump.api.models.ogc_exception import OGCExceptionResponse
 from ump.api.models.providers_config import ProcessConfig, ProviderConfig
 from ump.config import app_settings as config
 from ump.errors import InvalidUsage, OGCProcessException
 from ump.geoserver.geoserver import Geoserver
 from ump.utils import fetch_json, join_url_parts
-
 
 results_client_timeout = aiohttp.ClientTimeout(
     total=5,  # Set a reasonable timeout for the requests
@@ -25,6 +26,7 @@ results_client_timeout = aiohttp.ClientTimeout(
     sock_connect=2,  # Socket connection timeout
     sock_read=5,  # Socket read timeout
 )
+
 
 # TODO class violates Single Responsibility Principle (SRP), it mixes
 # business logic with data access logic and metadata handling
@@ -77,7 +79,7 @@ class Job:
         self.process_id = None
         self.provider_url = None
 
-        # TODO: this produces 404 if a job is beeing queried for which was 
+        # TODO: this produces 404 if a job is beeing queried for which was
         # stored with a user id, consider to distinguish between
         # 404, 401 and 403 here
         if job_id and not self._init_from_db(job_id, user):
@@ -92,9 +94,9 @@ class Job:
                             config.UMP_API_SERVER_URL,
                             f"{config.UMP_API_SERVER_URL_PREFIX}",
                             "jobs",
-                            job_id
+                            job_id,
                         ]
-                    )
+                    ),
                 )
             )
 
@@ -157,18 +159,21 @@ class Job:
                 %(process_title)s,
                 %(name)s,
                 %(process_version)s,
-                encode(
-                    sha512(
-                        convert_to(
-                            %(parameters)s :: json :: text || %(process_version)s || %(user_id)s,
-                            'UTF8'
-                        ) :: bytea
-                    ), 'base64'
-                )
+                %(hash)s
             )
         """
+        params = self._to_dict()
+        raw = (
+            (params.get("parameters") or "")
+            + (params.get("process_version") or "")
+            + (params.get("user_id") or "")
+        )
+        params["hash"] = base64.b64encode(
+            hashlib.sha512(raw.encode("utf-8")).digest()
+        ).decode("ascii")
+
         with DBHandler() as db:
-            db.run_query(query, query_params=self._to_dict())
+            db.run_query(query, query_params=params)
 
         logging.info(" --> Job %s for %s created.", self.job_id, self.process_id)
 
@@ -359,7 +364,7 @@ class Job:
                 config.UMP_API_SERVER_URL,
                 config.UMP_API_SERVER_URL_PREFIX,
                 "jobs",
-                f"{self.job_id}/results"
+                f"{self.job_id}/results",
             )
 
             job_dict["links"] = [
@@ -423,12 +428,11 @@ class Job:
         headers.update(provider_auth.headers)
 
         async with aiohttp.ClientSession(timeout=results_client_timeout) as session:
-
             results = await fetch_json(
                 session,
                 url=f"{self.provider_url}jobs/{self.remote_job_id}/results?f=json",
                 headers=headers,
-                auth=provider_auth.auth
+                auth=provider_auth.auth,
             )
 
             return results
@@ -476,12 +480,14 @@ class Job:
             JobStatus.failed.value: {
                 "type": "http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/failed",
                 "title": "Job failed",
-                "detail": self.message or "The job failed and no results are available.",
+                "detail": self.message
+                or "The job failed and no results are available.",
             },
             JobStatus.dismissed.value: {
                 "type": "http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/dismissed",
                 "title": "Job dismissed",
-                "detail": self.message or "The job was dismissed and no results are available.",
+                "detail": self.message
+                or "The job was dismissed and no results are available.",
             },
             JobStatus.running.value: {
                 "type": "http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/result-not-ready",

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -493,6 +493,7 @@ class Process:
                 )
             ) from e
         except aiohttp.ServerDisconnectedError as e:
+            logger.error("Client error during job submission: %s", e)
             raise OGCProcessException(
                 OGCExceptionResponse(
                     type="about:blank",
@@ -506,6 +507,7 @@ class Process:
                 )
             ) from e
         except aiohttp.ClientError as e:
+            logger.error("Client error during job submission: %s", e)
             raise OGCProcessException(
                 OGCExceptionResponse(
                     type="about:blank",

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -33,8 +33,9 @@ submission_request_timeout = aiohttp.ClientTimeout(
     connect=10,
     sock_connect=10,
     sock_read=120,
-    sock_write=120,
 )
+
+submission_post_timeout_seconds = 300
 
 
 # TODO: this is not an OGC API Process in a strict sense,
@@ -392,7 +393,8 @@ class Process:
                 response = await self._submit_remote_job(
                     session, str(provider.server_url),
                     request_body, provider_auth,
-                    headers
+                    headers,
+                    max_submit_seconds=max(submission_post_timeout_seconds, provider.timeout),
                 )
 
                 response_content = await fetch_response_content(response)
@@ -442,6 +444,9 @@ class Process:
                     )
                 ) from e
 
+            except OGCProcessException:
+                raise
+
             except Exception as e:
                 logger.exception("Unexpected error during job submission: \n%s", e)
 
@@ -462,16 +467,57 @@ class Process:
         request_body: dict,
         auth: remote_auth.ProviderAuth,
         headers: dict | None = None,
+        max_submit_seconds: int = submission_post_timeout_seconds,
     ) -> aiohttp.ClientResponse:
-        
-
-
-        response = await session.post(
-            f"{url}processes/{self.process_id}/execution",
-            json=request_body,
-            auth=auth.auth,
-            headers=headers
-        )
+        try:
+            response = await asyncio.wait_for(
+                session.post(
+                    f"{url}processes/{self.process_id}/execution",
+                    json=request_body,
+                    auth=auth.auth,
+                    headers=headers,
+                ),
+                timeout=max_submit_seconds,
+            )
+        except asyncio.TimeoutError as e:
+            raise OGCProcessException(
+                OGCExceptionResponse(
+                    type="about:blank",
+                    title="Remote job submission timed out",
+                    status=504,
+                    detail=(
+                        "Submitting the job to the remote server exceeded "
+                        f"the timeout of {max_submit_seconds} seconds."
+                    ),
+                    instance=f"/processes/{self.process_id_with_prefix}/execution",
+                )
+            ) from e
+        except aiohttp.ServerDisconnectedError as e:
+            raise OGCProcessException(
+                OGCExceptionResponse(
+                    type="about:blank",
+                    title="Remote server disconnected during submission",
+                    status=502,
+                    detail=(
+                        "The remote server closed the connection while "
+                        "the job submission request was in progress."
+                    ),
+                    instance=f"/processes/{self.process_id_with_prefix}/execution",
+                )
+            ) from e
+        except aiohttp.ClientError as e:
+            raise OGCProcessException(
+                OGCExceptionResponse(
+                    type="about:blank",
+                    title="Remote server communication failed",
+                    status=502,
+                    detail=(
+                        "Failed to submit the job to the remote server due "
+                        f"to a transport error: {e}"
+                    ),
+                    instance=f"/processes/{self.process_id_with_prefix}/execution",
+                )
+            ) from e
 
         if response.headers or response.content_type == "application/json":
             return response

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -32,7 +32,8 @@ submission_request_timeout = aiohttp.ClientTimeout(
     total=None,
     connect=10,
     sock_connect=10,
-    sock_read=60,
+    sock_read=120,
+    sock_write=120,
 )
 
 

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -20,11 +20,19 @@ from ump.utils import fetch_json, fetch_response_content
 
 logger = logging.getLogger(__name__)
 
-client_timeout = aiohttp.ClientTimeout(
-    total=5,  # Set a reasonable timeout for the requests
-    connect=2,  # Connection timeout
-    sock_connect=2,  # Socket connection timeout
-    sock_read=5,  # Socket read timeout
+metadata_request_timeout = aiohttp.ClientTimeout(
+    total=5,
+    connect=2,
+    sock_connect=2,
+    sock_read=5,
+)
+
+# Submission requests can carry very large payloads, so do not cap total duration.
+submission_request_timeout = aiohttp.ClientTimeout(
+    total=None,
+    connect=10,
+    sock_connect=10,
+    sock_read=60,
 )
 
 
@@ -196,7 +204,7 @@ class Process:
         auth_strategy = remote_auth.get_auth_strategy(provider_config.authentication)
         provider_auth = auth_strategy.get_auth()
 
-        async with aiohttp.ClientSession(timeout=client_timeout) as session:
+        async with aiohttp.ClientSession(timeout=metadata_request_timeout) as session:
             process_details = await fetch_json(
                 session=session,
                 url=f"{provider_config.server_url}processes/{self.process_id}",
@@ -378,7 +386,7 @@ class Process:
 
         # TODO: if a server decides to ignore the Prefer header, response contains results, not job status info
         # need to adress this case!
-        async with aiohttp.ClientSession(timeout=client_timeout) as session:
+        async with aiohttp.ClientSession(timeout=submission_request_timeout) as session:
             try:
                 response = await self._submit_remote_job(
                     session, str(provider.server_url),
@@ -600,7 +608,7 @@ class Process:
 
         headers.update(provider_auth.headers)
 
-        async with aiohttp.ClientSession(timeout=client_timeout) as session:
+        async with aiohttp.ClientSession(timeout=metadata_request_timeout) as session:
 
             while True:
                 status_info = await self._fetch_remote_job_status(

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -1,4 +1,6 @@
 import asyncio
+import base64
+import hashlib
 import json
 import logging
 import re
@@ -8,14 +10,14 @@ from multiprocessing import dummy
 import aiohttp
 from flask import g
 
-from ump.api import remote_auth
 import ump.api.providers as providers
+from ump.api import remote_auth
 from ump.api.db_handler import engine
 from ump.api.models.job import Job, JobStatus
 from ump.api.models.ogc_exception import OGCExceptionResponse
 from ump.api.models.providers_config import ProcessConfig, ProviderConfig
 from ump.config import app_settings as config
-from ump.errors import InvalidUsage, OGCProcessException
+from ump.errors import OGCProcessException
 from ump.utils import fetch_json, fetch_response_content
 
 logger = logging.getLogger(__name__)
@@ -58,7 +60,7 @@ class Process:
         self.links = None
 
         match = re.search(r"([^:]+):(.*)", self.process_id_with_prefix)
-        
+
         if not match:
             logger.warning(
                 "Process ID '%s' does not match pattern 'provider:process_id'. "
@@ -137,7 +139,7 @@ class Process:
 
             # check if token was provided by the user
             auth = getattr(g, "auth_token", None)
-            
+
             if not auth:
                 logger.warning(
                     "User is not allowed to access process %s. "
@@ -149,32 +151,28 @@ class Process:
                         type="about:blank",
                         title="Unauthorized.",
                         status=401,
-                        detail=(
-                            "The request lacks necessary authentication details."
-                        ),
+                        detail=("The request lacks necessary authentication details."),
                         instance=f"/processes/{self.process_id_with_prefix}",
                     )
                 )
-            
+
             role_name = f"{self.provider_prefix}_{self.process_id}"
 
             realm_roles = auth.get("realm_access", {}).get("roles", []) if auth else []
 
             client_roles = (
                 (
-                    auth.get(
-                        "resource_access", {}
-                        ).get(
-                            config.UMP_KEYCLOAK_CLIENT_ID, {}
-                        ).get(
-                            "roles", [])
-                        )
+                    auth.get("resource_access", {})
+                    .get(config.UMP_KEYCLOAK_CLIENT_ID, {})
+                    .get("roles", [])
+                )
                 if auth
                 else []
             )
 
             allowed = any(
-                r in realm_roles + client_roles for r in [self.provider_prefix, role_name]
+                r in realm_roles + client_roles
+                for r in [self.provider_prefix, role_name]
             )
 
             if not allowed:
@@ -211,7 +209,7 @@ class Process:
                 session=session,
                 url=f"{provider_config.server_url}processes/{self.process_id}",
                 auth=provider_auth.auth,
-                headers=provider_auth.headers
+                headers=provider_auth.headers,
             )
             for key in process_details:
                 setattr(self, key, process_details[key])
@@ -308,6 +306,17 @@ class Process:
 
         return False
 
+    @staticmethod
+    def compute_job_hash(parameters_json, process_version, user_id):
+        """
+        Compute the cache hash for a job in Python.
+        Must match the PostgreSQL formula:
+        encode(sha512(convert_to(params::json::text || version || user_id, 'UTF8')), 'base64')
+        """
+        raw = parameters_json + process_version + (user_id or "")
+        digest = hashlib.sha512(raw.encode("utf-8")).digest()
+        return base64.b64encode(digest).decode("ascii")
+
     def check_for_cache(self, parameters, user_id):
         """
         Checks if the job has already been executed. Returns the job id if it has, None otherwise.
@@ -319,26 +328,13 @@ class Process:
         if process_config.deterministic:
             return None
 
-        sql = """
-        select job_id from jobs where hash = encode(
-            sha512(
-                convert_to(
-                    %(parameters)s :: json :: text || %(process_version)s || %(user_id)s,
-                    'UTF8'
-                )
-            ),
-            'base64'
+        hash_value = self.compute_job_hash(
+            json.dumps(parameters), self.version, user_id
         )
-        """
+
+        sql = "select job_id from jobs where hash = %(hash)s"
         with engine.begin() as conn:
-            result = conn.exec_driver_sql(
-                sql,
-                {
-                    "parameters": json.dumps(parameters),
-                    "process_version": self.version,
-                    "user_id": user_id,
-                },
-            )
+            result = conn.exec_driver_sql(sql, {"hash": hash_value})
             for row in result:
                 return row.job_id
         return None
@@ -377,9 +373,9 @@ class Process:
             return Job(job_id, user)
 
         headers = {
-                "Content-type": "application/json",
-                "Accept": "application/json",
-                "Prefer": "respond-async",
+            "Content-type": "application/json",
+            "Accept": "application/json",
+            "Prefer": "respond-async",
         }
 
         auth_strategy = remote_auth.get_auth_strategy(provider.authentication)
@@ -391,10 +387,14 @@ class Process:
         async with aiohttp.ClientSession(timeout=submission_request_timeout) as session:
             try:
                 response = await self._submit_remote_job(
-                    session, str(provider.server_url),
-                    request_body, provider_auth,
+                    session,
+                    str(provider.server_url),
+                    request_body,
+                    provider_auth,
                     headers,
-                    max_submit_seconds=max(submission_post_timeout_seconds, provider.timeout),
+                    max_submit_seconds=max(
+                        submission_post_timeout_seconds, provider.timeout
+                    ),
                 )
 
                 response_content = await fetch_response_content(response)
@@ -410,13 +410,14 @@ class Process:
                 headers.pop("Prefer", None)
                 # this can probably be omitted here and deferred for _wait_for_status
                 remote_job_status_info = await self._fetch_remote_job_status(
-                    session, str(provider.server_url), remote_job_id, provider_auth,
-                    headers # remove prefer header
+                    session,
+                    str(provider.server_url),
+                    remote_job_id,
+                    provider_auth,
+                    headers,  # remove prefer header
                 )
 
-                self._update_job_from_status(
-                    job, remote_job_status_info
-                )
+                self._update_job_from_status(job, remote_job_status_info)
 
                 job.update()
 
@@ -555,7 +556,8 @@ class Process:
         return job
 
     async def _fetch_remote_job_status(
-        self, session: aiohttp.ClientSession,
+        self,
+        session: aiohttp.ClientSession,
         url: str,
         remote_job_id: str,
         auth: remote_auth.ProviderAuth,
@@ -615,9 +617,7 @@ class Process:
 
         try:
             await asyncio.wait_for(
-                self._poll_job_until_finished(
-                    job, provider_config
-                ),
+                self._poll_job_until_finished(job, provider_config),
                 timeout=timeout_seconds,
             )
         except asyncio.TimeoutError:
@@ -644,8 +644,8 @@ class Process:
             await self._store_results_if_needed(job)
 
     async def _poll_job_until_finished(
-            self, job: Job, provider_config: ProviderConfig
-        ) -> dict:
+        self, job: Job, provider_config: ProviderConfig
+    ) -> dict:
 
         headers = {
             "Content-type": "application/json",
@@ -658,20 +658,19 @@ class Process:
         headers.update(provider_auth.headers)
 
         async with aiohttp.ClientSession(timeout=metadata_request_timeout) as session:
-
             while True:
                 status_info = await self._fetch_remote_job_status(
                     session,
                     str(provider_config.server_url),
                     job.remote_job_id,
                     provider_auth,
-                    headers
+                    headers,
                 )
                 self._update_job_from_status(job, status_info)
                 if self.is_finished(status_info):
                     break
                 await asyncio.sleep(config.UMP_REMOTE_JOB_STATUS_REQUEST_INTERVAL)
-        
+
         return status_info
 
     def _update_job_from_status(self, job: Job, status_info):


### PR DESCRIPTION
When a job is created the full input object was sent to db in order to create a hash server side:

```python
encode(
                    sha512(
                        convert_to(
                            %(parameters)s :: json :: text || %(process_version)s || %(user_id)s,
                            'UTF8'
                        ) :: bytea
                    ), 'base64'
                )
```               
      
For large input data that means the size of the query could be overwhelming for the db to handle, in this case the connection will be terminated, the server drops the TCP connection mid-transfer. `Job.insert()` and `Job.check_for_cache()` methods both did that. The fix is to compute the hash in python.