### PR TITLE
Bug/try except job results

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.2.8"
+current_version = "2.2.9"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.2.7"
+current_version = "2.2.8"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.2.6"
+current_version = "2.2.7"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.2.8"
+version = "2.2.9"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ exclude = [
 
 [tool.poetry]
 name = "ump"
-version = "2.2.7"
+version = "2.2.8"
 description = "server federation api, OGC Api Processes-based to connect model servers and centralize access to them"
 authors = [
     "Rico Herzog <rico.herzog@hcu-hamburg.de>",

--- a/src/ump/api/models/job.py
+++ b/src/ump/api/models/job.py
@@ -21,10 +21,10 @@ from ump.geoserver.geoserver import Geoserver
 from ump.utils import fetch_json, join_url_parts
 
 results_client_timeout = aiohttp.ClientTimeout(
-    total=5,  # Set a reasonable timeout for the requests
-    connect=2,  # Connection timeout
-    sock_connect=2,  # Socket connection timeout
-    sock_read=5,  # Socket read timeout
+    total=None,  # No hard cap — model outputs can be large
+    connect=10,  # Connection timeout
+    sock_connect=10,  # Socket connection timeout
+    sock_read=120,  # Allow up to 2 minutes without new data before giving up
 )
 
 

--- a/src/ump/api/models/job.py
+++ b/src/ump/api/models/job.py
@@ -415,6 +415,11 @@ class Job:
         if self.status != JobStatus.successful.value:
             self.results_not_available()
 
+        logging.debug(
+            "Fetching results for job %s from remote (remote job: %s).",
+            self.job_id,
+            self.remote_job_id,
+        )
         headers = {
             "Content-type": "application/json",
             "Accept": "application/json",
@@ -434,7 +439,7 @@ class Job:
                 headers=headers,
                 auth=provider_auth.auth,
             )
-
+            logging.debug("Results for job %s fetched successfully.", self.job_id)
             return results
 
     async def results_to_geoserver(self):
@@ -509,6 +514,13 @@ class Job:
                 "detail": "No results are available for this job.",
             },
         )
+
+        if self.status not in status_map:
+            logging.warning(
+                "Results requested for job %s with unexpected status '%s'.",
+                self.job_id,
+                self.status,
+            )
 
         raise OGCProcessException(
             OGCExceptionResponse(

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -23,10 +23,10 @@ from ump.utils import fetch_json, fetch_response_content
 logger = logging.getLogger(__name__)
 
 metadata_request_timeout = aiohttp.ClientTimeout(
-    total=5,
-    connect=2,
-    sock_connect=2,
-    sock_read=5,
+    total=30,
+    connect=5,
+    sock_connect=5,
+    sock_read=30,
 )
 
 # Submission requests can carry very large payloads, so do not cap total duration.
@@ -657,13 +657,7 @@ class Process:
         # setting job to "failed" even if remote job was successfull!
         except Exception as e:
             logger.error("Error while waiting for job results: %s", e)
-            self._set_job_failed(
-                job,
-                (
-                    "An unexpected error occurred while waiting for job results."
-                    "See the logs for details"
-                ),
-            )
+            self._set_job_failed(job, str(e))
             return
 
         try:

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -606,13 +606,32 @@ class Process:
         )
 
     def _wait_for_results_async(self, job: Job):
-        asyncio.run(self._wait_for_results(job))
+        try:
+            asyncio.run(self._wait_for_results(job))
+        except Exception as e:
+            logger.error(
+                "Unhandled exception in background results thread for job %s: %s",
+                job.job_id,
+                e,
+            )
 
     async def _wait_for_results(self, job: Job):
         logger.info("Thread started to wait for results.")
-        provider_config: ProviderConfig = providers.get_providers()[
-            self.provider_prefix
-        ]
+        try:
+            provider_config: ProviderConfig = providers.get_providers()[
+                self.provider_prefix
+            ]
+        except KeyError:
+            logger.error(
+                "Provider '%s' not found in configuration. Cannot wait for results of job %s.",
+                self.provider_prefix,
+                job.job_id,
+            )
+            self._set_job_failed(
+                job,
+                f"Provider '{self.provider_prefix}' is no longer available.",
+            )
+            return
         timeout_seconds = provider_config.timeout
 
         try:
@@ -640,8 +659,16 @@ class Process:
                     "See the logs for details"
                 ),
             )
-        else:
+            return
+
+        try:
             await self._store_results_if_needed(job)
+        except Exception as e:
+            logger.error(
+                "Unexpected error during post-processing of results for job %s: %s",
+                job.job_id,
+                e,
+            )
 
     async def _poll_job_until_finished(
         self, job: Job, provider_config: ProviderConfig

--- a/src/ump/api/models/process.py
+++ b/src/ump/api/models/process.py
@@ -640,6 +640,11 @@ class Process:
                 timeout=timeout_seconds,
             )
         except asyncio.TimeoutError:
+            logger.error(
+                "Timed out waiting for remote job %s to finish (limit: %s sec.).",
+                job.job_id,
+                provider_config.timeout,
+            )
             self._set_job_failed(
                 job,
                 (
@@ -673,6 +678,11 @@ class Process:
     async def _poll_job_until_finished(
         self, job: Job, provider_config: ProviderConfig
     ) -> dict:
+        logger.info(
+            "Polling remote job status for job %s (remote: %s).",
+            job.job_id,
+            job.remote_job_id,
+        )
 
         headers = {
             "Content-type": "application/json",
@@ -695,12 +705,25 @@ class Process:
                 )
                 self._update_job_from_status(job, status_info)
                 if self.is_finished(status_info):
+                    logger.info(
+                        "Remote job %s finished with status '%s'.",
+                        job.job_id,
+                        status_info.get("status"),
+                    )
                     break
                 await asyncio.sleep(config.UMP_REMOTE_JOB_STATUS_REQUEST_INTERVAL)
 
         return status_info
 
     def _update_job_from_status(self, job: Job, status_info):
+        new_status = status_info.get("status", "")
+        if new_status != job.status:
+            logger.debug(
+                "Job %s status: %s -> %s",
+                job.job_id,
+                job.status,
+                new_status,
+            )
         job.started = status_info.get("started")
         job.created = status_info.get("created")
         job.updated = status_info.get("updated")
@@ -713,6 +736,7 @@ class Process:
         job.update()
 
     def _set_job_failed(self, job: Job, message: str):
+        logger.error("Setting job %s to failed: %s", job.job_id, message)
         job.status = JobStatus.failed.value
         job.message = message
 
@@ -738,7 +762,13 @@ class Process:
                 providers.check_result_storage(self.provider_prefix, self.process_id)
                 == "geoserver"
             ):
+                logger.debug("Storing results for job %s to geoserver.", job.job_id)
                 await job.results_to_geoserver()
+            else:
+                logger.debug(
+                    "No geoserver result storage configured for job %s, skipping.",
+                    job.job_id,
+                )
         except Exception as e:
             logger.error("Could not store results for job %s: %s", job.job_id, e)
 


### PR DESCRIPTION
Too tightly configured timeouts triggered a bug where an exception was swallowed and an otherwise successful remote job was marked as `failed` within the `_wait_for_results` subroutine. This hotfix adresses the immediate effects. The whole section is a bit brittle and needs more careful review, though.

This fix was tested and successfully handles the described issue.